### PR TITLE
added uninstall.php

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * 
+ * This file runs when the plugin in uninstalled (deleted).
+ * This will not run when the plugin is deactivated.
+ * Ideally you will add all your clean-up scripts here
+ * that will clean-up unused meta, options, etc. in the database.
+ *
+ */
+
+// If plugin is not being uninstalled, exit (do nothing)
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+	exit;
+}
+
+// Do something here if plugin is being uninstalled.


### PR DESCRIPTION
Because its a good idea for most plugin authors to clean-up after themselves if their plugin is removed from a website. Database options, etc. (if it does add to the database.)