### PR TITLE
added options to allow control of Post Type and Taxonomy Options

### DIFF
--- a/build-plugin.sh
+++ b/build-plugin.sh
@@ -21,7 +21,7 @@ CLASS=${NAME// /_}
 TOKEN=$( tr '[A-Z]' '[a-z]' <<< $CLASS)
 SLUG=${TOKEN//_/-}
 
-git clone git@github.com:hlashbrooke/$DEFAULT_SLUG.git $FOLDER/$SLUG
+git clone git@github.com:thirdwunder/$DEFAULT_SLUG.git $FOLDER/$SLUG
 
 echo "Removing git files..."
 

--- a/build-plugin.sh
+++ b/build-plugin.sh
@@ -21,7 +21,7 @@ CLASS=${NAME// /_}
 TOKEN=$( tr '[A-Z]' '[a-z]' <<< $CLASS)
 SLUG=${TOKEN//_/-}
 
-git clone git@github.com:thirdwunder/$DEFAULT_SLUG.git $FOLDER/$SLUG
+git clone git@github.com:hlashbrooke/$DEFAULT_SLUG.git $FOLDER/$SLUG
 
 echo "Removing git files..."
 

--- a/includes/class-wordpress-plugin-template.php
+++ b/includes/class-wordpress-plugin-template.php
@@ -122,11 +122,11 @@ class WordPress_Plugin_Template {
 	 * @param  string $description Description of post type
 	 * @return object              Post type class object
 	 */
-	public function register_post_type ( $post_type = '', $plural = '', $single = '', $description = '' ) {
+	public function register_post_type ( $post_type = '', $plural = '', $single = '', $description = '', $options = array() ) {
 
 		if ( ! $post_type || ! $plural || ! $single ) return;
 
-		$post_type = new WordPress_Plugin_Template_Post_Type( $post_type, $plural, $single, $description );
+		$post_type = new WordPress_Plugin_Template_Post_Type( $post_type, $plural, $single, $description, $options );
 
 		return $post_type;
 	}
@@ -139,11 +139,11 @@ class WordPress_Plugin_Template {
 	 * @param  array  $post_types Post types to which this taxonomy applies
 	 * @return object             Taxonomy class object
 	 */
-	public function register_taxonomy ( $taxonomy = '', $plural = '', $single = '', $post_types = array() ) {
+	public function register_taxonomy ( $taxonomy = '', $plural = '', $single = '', $post_types = array(), $taxonomy_args = array() ) {
 
 		if ( ! $taxonomy || ! $plural || ! $single ) return;
 
-		$taxonomy = new WordPress_Plugin_Template_Taxonomy( $taxonomy, $plural, $single, $post_types );
+		$taxonomy = new WordPress_Plugin_Template_Taxonomy( $taxonomy, $plural, $single, $post_types, $taxonomy_args );
 
 		return $taxonomy;
 	}

--- a/includes/lib/class-wordpress-plugin-template-post-type.php
+++ b/includes/lib/class-wordpress-plugin-template-post-type.php
@@ -36,7 +36,15 @@ class WordPress_Plugin_Template_Post_Type {
 	 */
 	public $description;
 
-	public function __construct ( $post_type = '', $plural = '', $single = '', $description = '' ) {
+	/**
+	 * The options of the custom post type.
+	 * @var 	array
+	 * @access  public
+	 * @since 	1.0.0
+	 */
+	public $options;
+
+	public function __construct ( $post_type = '', $plural = '', $single = '', $description = '', $options = array() ) {
 
 		if ( ! $post_type || ! $plural || ! $single ) return;
 
@@ -45,6 +53,7 @@ class WordPress_Plugin_Template_Post_Type {
 		$this->plural = $plural;
 		$this->single = $single;
 		$this->description = $description;
+		$this->options = $options;
 
 		// Regsiter post type
 		add_action( 'init' , array( $this, 'register_post_type' ) );
@@ -96,6 +105,8 @@ class WordPress_Plugin_Template_Post_Type {
 			'menu_position' => 5,
 			'menu_icon' => 'dashicons-admin-post',
 		);
+
+		$args = array_merge($args, $this->options);
 
 		register_post_type( $this->post_type, apply_filters( $this->post_type . '_register_args', $args, $this->post_type ) );
 	}

--- a/includes/lib/class-wordpress-plugin-template-taxonomy.php
+++ b/includes/lib/class-wordpress-plugin-template-taxonomy.php
@@ -36,7 +36,15 @@ class WordPress_Plugin_Template_Taxonomy {
 	 */
 	public $post_types;
 
-	public function __construct ( $taxonomy = '', $plural = '', $single = '', $post_types = array() ) {
+  /**
+	 * The array of taxonomy arguments
+	 * @var 	array
+	 * @access  public
+	 * @since 	1.0.0
+	 */
+	public $taxonomy_args;
+
+	public function __construct ( $taxonomy = '', $plural = '', $single = '', $post_types = array(), $tax_args = array() ) {
 
 		if ( ! $taxonomy || ! $plural || ! $single ) return;
 
@@ -48,6 +56,7 @@ class WordPress_Plugin_Template_Taxonomy {
 			$post_types = array( $post_types );
 		}
 		$this->post_types = $post_types;
+		$this->taxonomy_args = $tax_args;
 
 		// Register taxonomy
 		add_action('init', array( $this, 'register_taxonomy' ) );
@@ -94,6 +103,8 @@ class WordPress_Plugin_Template_Taxonomy {
             'rewrite' => true,
             'sort' => '',
         );
+
+        $args = array_merge($args, $this->taxonomy_args);
 
         register_taxonomy( $this->taxonomy, $this->post_types, apply_filters( $this->taxonomy . '_register_args', $args, $this->taxonomy, $this->post_types ) );
     }


### PR DESCRIPTION
An options array can now be passed to define extra details of a post type and a taxonomy.

eg: Post Type, you can now pass an array to define
menu_icon, rewrite, archive settings, search exclusion.

```
WordPress_Plugin_Template()->register_post_type(
                        'post_type',
                        __( 'Plural Name',     'wordpress-plugin-template' ),
                        __( 'Singular Name',      'wordpress-plugin-template' ),
                        __( 'Description', 'wordpress-plugin-template'),
                        array(
                          'menu_icon'=>plugins_url( 'assets/img/cpt-icon.png', __FILE__ ),
                          'rewrite' => array('slug' =>'post_type_slug'),
                          'exclude_from_search' => false,
                          'has_archive'     => true,
                          'supports' => array( 'title', 'editor', 'excerpt', 'thumbnail', 'page-attributes' ),
                        )
                    );
```

eg: Taxonomy
hierarchical options to differentiate between a category or tag type taxonomy, rewrite options with slug and hierarchical display

```
WordPress_Plugin_Template()->register_taxonomy(
    'taxonomy_name',
    __( 'Plural Name', 'wordpress-plugin-template' ),
    __( 'Singular Name', 'wordpress-plugin-template' ),
    'post_type',
    array(
      'hierarchical'=>false,
      'rewrite'=>array('slug'=>'taxonomy_slug', 'hierarchical' => true),
    )
  );
```