### PR TITLE
Update git clone in build-plugin.sh to use https

### DIFF
--- a/build-plugin.sh
+++ b/build-plugin.sh
@@ -21,7 +21,7 @@ CLASS=${NAME// /_}
 TOKEN=$( tr '[A-Z]' '[a-z]' <<< $CLASS)
 SLUG=${TOKEN//_/-}
 
-git clone git@github.com:hlashbrooke/$DEFAULT_SLUG.git $FOLDER/$SLUG
+git clone https://github.com/hlashbrooke/$DEFAULT_SLUG.git $FOLDER/$SLUG
 
 echo "Removing git files..."
 


### PR DESCRIPTION
While using build-plugin.sh I got an error message stating that I
did not have permission to clone the repository. Users are not
required to have a github account or have special permissions to
clone the repo when using https, so I have updated the script to
use https instead of ssh to make the script more compatible and
accessible.