### PR TITLE
RESOLVE hlashbrooke/WordPress-Plugin-Template#30

### DIFF
--- a/includes/lib/class-wordpress-plugin-template-admin-api.php
+++ b/includes/lib/class-wordpress-plugin-template-admin-api.php
@@ -109,7 +109,7 @@ class WordPress_Plugin_Template_Admin_API {
 			case 'checkbox_multi':
 				foreach ( $field['options'] as $k => $v ) {
 					$checked = false;
-					if ( in_array( $k, $data ) ) {
+					if ( in_array( $k, (array) $data ) ) {
 						$checked = true;
 					}
 					$html .= '<label for="' . esc_attr( $field['id'] . '_' . $k ) . '" class="checkbox_multi"><input type="checkbox" ' . checked( $checked, true, false ) . ' name="' . esc_attr( $option_name ) . '[]" value="' . esc_attr( $k ) . '" id="' . esc_attr( $field['id'] . '_' . $k ) . '" /> ' . $v . '</label> ';
@@ -142,7 +142,7 @@ class WordPress_Plugin_Template_Admin_API {
 				$html .= '<select name="' . esc_attr( $option_name ) . '[]" id="' . esc_attr( $field['id'] ) . '" multiple="multiple">';
 				foreach ( $field['options'] as $k => $v ) {
 					$selected = false;
-					if ( in_array( $k, $data ) ) {
+					if ( in_array( $k, (array) $data ) ) {
 						$selected = true;
 					}
 					$html .= '<option ' . selected( $selected, true, false ) . ' value="' . esc_attr( $k ) . '">' . $v . '</option>';


### PR DESCRIPTION
Fixes the `Warning: in_array() expects parameter 2 to be array, string given in` while none of the options are selected or checked in case of Multi-select checkbox.